### PR TITLE
Updated CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.8'
-          - 'nightly'
+          - "1.11"
+          - "nightly"
         os:
           - ubuntu-latest
         arch:
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.8'
+          version: "1.11"
       - run: |
           julia --project=docs -e '
             using Pkg


### PR DESCRIPTION
This pull request updates the CI workflow in `.github/workflows/ci.yml` to use Julia version 1.11 instead of 1.8.

CI workflow updates:
- Updated the matrix of Julia versions to include `1.11` and retain `nightly`, replacing the previous `1.8` version.
- Changed the `setup-julia` action to use Julia version `1.11` instead of `1.8`.