### PR TITLE
Update to latest version of NiaARM.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 [compat]
 CSV = "0.10.7"
 DataFrames = "1.4.4"
-NiaARM = "0.2.0"
+NiaARM = "0.3.0"
 Plots = "1.38.0"
 StatsBase = "0.34.5"
 StatsPlots = "0.15.7"

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ using NiaARM
 dataset = Dataset("datasets/random_sportydatagen.csv")
 
 # vector of antecedents
-antecedent = Attribute[
+antecedent = [
     NumericalAttribute("duration", 50, 65),
     NumericalAttribute("distance", 15.0, 40.0),
 ]
 
 # vector of consequents
-consequent = Attribute[
+consequent = [
     NumericalAttribute("calories", 200.0, 450.0),
     NumericalAttribute("descent", 50.0, 140.0),
 ]

--- a/examples/abalone.jl
+++ b/examples/abalone.jl
@@ -3,11 +3,11 @@ using NarmViz
 
 dataset = Dataset(joinpath(@__DIR__, "..", "datasets", "Abalone.csv"))
 
-antecedent = Attribute[
+antecedent = [
     NumericalAttribute("Rings", 5, 19),
 ]
 
-consequent = Attribute[
+consequent = [
     CategoricalAttribute("Sex", "M")
 ]
 

--- a/examples/barchart_run.jl
+++ b/examples/barchart_run.jl
@@ -5,13 +5,13 @@ using NiaARM
 dataset = Dataset(joinpath(@__DIR__, "..", "datasets", "random_sportydatagen.csv"))
 
 # vector of antecedents
-antecedent = Attribute[
+antecedent = [
     NumericalAttribute("duration", 50, 65),
     NumericalAttribute("distance", 15.0, 40.0),
 ]
 
 # vector of consequents
-consequent = Attribute[
+consequent = [
     NumericalAttribute("calories", 200.0, 450.0),
     NumericalAttribute("descent", 50.0, 140.0),
 ]

--- a/examples/boxplot_run.jl
+++ b/examples/boxplot_run.jl
@@ -5,13 +5,13 @@ using NiaARM
 dataset = Dataset(joinpath(@__DIR__, "..", "datasets", "random_sportydatagen.csv"))
 
 # vector of antecedents
-antecedent = Attribute[
+antecedent = [
     NumericalAttribute("duration", 50, 65),
     NumericalAttribute("distance", 15.0, 40.0),
 ]
 
 # vector of consequents
-consequent = Attribute[
+consequent = [
     NumericalAttribute("calories", 200.0, 450.0),
     NumericalAttribute("descent", 50.0, 140.0),
 ]

--- a/examples/hexbin_run.jl
+++ b/examples/hexbin_run.jl
@@ -5,13 +5,13 @@ using NiaARM
 dataset = Dataset(joinpath(@__DIR__, "..", "datasets", "random_sportydatagen.csv"))
 
 # vector of antecedents
-antecedent = Attribute[
+antecedent = [
     NumericalAttribute("duration", 50, 65),
     NumericalAttribute("distance", 15.0, 40.0),
 ]
 
 # vector of consequents
-consequent = Attribute[
+consequent = [
     NumericalAttribute("calories", 200.0, 450.0),
     NumericalAttribute("descent", 50.0, 140.0),
 ]

--- a/examples/linechart_run.jl
+++ b/examples/linechart_run.jl
@@ -5,13 +5,13 @@ using NiaARM
 dataset = Dataset(joinpath(@__DIR__, "..", "datasets", "random_sportydatagen.csv"))
 
 # vector of antecedents
-antecedent = Attribute[
+antecedent = [
     NumericalAttribute("duration", 50, 65),
     NumericalAttribute("distance", 15.0, 40.0),
 ]
 
 # vector of consequents
-consequent = Attribute[
+consequent = [
     NumericalAttribute("calories", 200.0, 450.0),
     NumericalAttribute("descent", 50.0, 140.0),
 ]

--- a/examples/scatter_run.jl
+++ b/examples/scatter_run.jl
@@ -5,13 +5,13 @@ using NiaARM
 dataset = Dataset(joinpath(@__DIR__, "..", "datasets", "random_sportydatagen.csv"))
 
 # vector of antecedents
-antecedent = Attribute[
+antecedent = [
     NumericalAttribute("duration", 50, 65),
     NumericalAttribute("distance", 15.0, 40.0),
 ]
 
 # vector of consequents
-consequent = Attribute[
+consequent = [
     NumericalAttribute("calories", 200.0, 450.0),
     NumericalAttribute("descent", 50.0, 140.0),
 ]

--- a/examples/violin_run.jl
+++ b/examples/violin_run.jl
@@ -5,13 +5,13 @@ using NiaARM
 dataset = Dataset(joinpath(@__DIR__, "..", "datasets", "random_sportydatagen.csv"))
 
 # vector of antecedents
-antecedent = Attribute[
+antecedent = [
     NumericalAttribute("duration", 50, 65),
     NumericalAttribute("distance", 15.0, 40.0),
 ]
 
 # vector of consequents
-consequent = Attribute[
+consequent = [
     NumericalAttribute("calories", 200.0, 450.0),
     NumericalAttribute("descent", 50.0, 140.0),
 ]


### PR DESCRIPTION
- The Attribute and Feature abstract types was renamed to AbstractAttribute and AbstractFeature respectively in NiaARM.jl v0.3.0.
- Specifying the vector type  AbstractAttribute[] is no longer required for defining antecedents and consequents.